### PR TITLE
Bound the in-memory report registry to avoid unbounded growth

### DIFF
--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -13,6 +13,7 @@ import traceback
 import uuid
 import warnings
 from asyncio import Queue, Task
+from collections import OrderedDict
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -44,11 +45,25 @@ logger = logging.getLogger(__name__)
 
 # Per-session progress queues - keyed by session_id, cleaned up after analysis completes
 _progress_queues: dict[str, asyncio.Queue[dict[str, object]]] = {}
-_report_registry: dict[str, Analyzer] = {}
+
+# Completed reports, keyed by report_id, used by the drilldown routes.
+# Each stored Analyzer holds the full parsed-pcap pandas frames, so the registry
+# is bounded and evicts the least-recently-used report once the cap is reached.
+# Ordered oldest-to-newest; reads move the entry to the end (see _require_analyzer).
+_report_registry: OrderedDict[str, Analyzer] = OrderedDict()
 _executor = ThreadPoolExecutor(max_workers=4)
 
 # Constants
 PCAP_CHUNK_SIZE = 1024 * 1024  # 1MB
+MAX_STORED_REPORTS = 32  # Cap on retained reports before the oldest is evicted.
+
+
+def _store_analyzer(report_id: str, analyzer: Analyzer) -> None:
+    """Register an analyzer for later drilldown, evicting the oldest if over cap."""
+    _report_registry[report_id] = analyzer
+    _report_registry.move_to_end(report_id)
+    while len(_report_registry) > MAX_STORED_REPORTS:
+        _report_registry.popitem(last=False)
 
 
 def sanitize_for_json(obj: JSONValue) -> JSONValue:
@@ -129,7 +144,7 @@ def run_analysis(
         )
 
         report_id = str(uuid.uuid4())
-        _report_registry[report_id] = analyzer
+        _store_analyzer(report_id, analyzer)
 
         _emit(session_id, "report", 80, "Generating report...")
         report = Report(analyzer, report_id=report_id)
@@ -292,6 +307,8 @@ def _require_analyzer(report_id: str) -> Analyzer:
     analyzer = _report_registry.get(report_id)
     if analyzer is None:
         raise HTTPException(status_code=404, detail=f"Report not found: {report_id}")
+    # Mark this report as recently used so active drilldowns are not evicted first.
+    _report_registry.move_to_end(report_id)
     return analyzer
 
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -21,8 +21,12 @@ from fastapi.testclient import TestClient
 # or if the src/app directory is added to PYTHONPATH.
 # If not, we might need to adjust sys.path or use a different import strategy.
 from src.app.main import (
+    MAX_STORED_REPORTS,
     _emit,
     _progress_queues,
+    _report_registry,
+    _require_analyzer,
+    _store_analyzer,
     app,
     logger,
     run_analysis,
@@ -37,6 +41,44 @@ def clear_progress_queues():
     _progress_queues.clear()
     yield
     _progress_queues.clear()
+
+
+@pytest.fixture
+def clear_report_registry():
+    """Clear the report registry around a test case."""
+    _report_registry.clear()
+    yield
+    _report_registry.clear()
+
+
+def test_store_analyzer_bounds_registry(clear_report_registry):
+    """Keep the report registry capped when more reports are stored than the limit."""
+    total = MAX_STORED_REPORTS + 10
+    for i in range(total):
+        _store_analyzer(f"report-{i}", Mock())
+
+    # Without a bound the registry would hold every insert; it must stay capped.
+    assert len(_report_registry) == MAX_STORED_REPORTS
+
+    # The oldest reports are evicted first; only the most recent survive.
+    assert "report-0" not in _report_registry
+    assert f"report-{total - 1}" in _report_registry
+
+
+def test_require_analyzer_keeps_recently_used(clear_report_registry):
+    """Evict the least-recently-used report rather than a recently accessed one."""
+    for i in range(MAX_STORED_REPORTS):
+        _store_analyzer(f"report-{i}", Mock())
+
+    # Touch the oldest report so it counts as recently used.
+    _require_analyzer("report-0")
+
+    # One more insert should evict report-1 (now the oldest) and spare report-0.
+    _store_analyzer("report-new", Mock())
+
+    assert len(_report_registry) == MAX_STORED_REPORTS
+    assert "report-0" in _report_registry
+    assert "report-1" not in _report_registry
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi, I do supply-chain-security work and was reading through the eleVADR backend. I noticed the completed-report registry can grow without bound, so here is a small hardening fix.

In `backend/src/app/main.py`, `_report_registry` stores the full `Analyzer` for each analysis, and each Analyzer holds the parsed-pcap pandas frames (`traffic_df`, `endpoints_df`, `services_df`). The only writes are the insert in `run_analysis` and the read in `_require_analyzer`; nothing ever evicts or caps it. Its sibling dict `_progress_queues` does get cleaned up (the WebSocket `finally` block pops it), but the heavier report registry keeps every entry for the lifetime of the worker, so memory climbs steadily as more PCAPs are analyzed.

The change backs the registry with an `OrderedDict` capped at `MAX_STORED_REPORTS` (32) and evicts the oldest entry once the cap is reached. Reads through `_require_analyzer` move the entry to the end, so a report that is actively being drilled into is not the first one evicted. The existing drilldown read path keeps working for recent reports, which is the common case.

Tests: I added two cases in `backend/tests/test_main.py` covering the size cap and the least-recently-used eviction order. Both pass under Python 3.14, and I confirmed they fail against the previous unbounded behavior. The full `test_main.py` suite (14 tests) stays green and ruff is clean on the edited source.

If you would rather I raise the 32 default differently, or handle eviction some other way (a TTL or an explicit delete on drilldown completion were alternatives I considered), happy to adjust. Thanks for the tool.